### PR TITLE
Revert reminder

### DIFF
--- a/app/controllers/reminders/new.js
+++ b/app/controllers/reminders/new.js
@@ -12,6 +12,6 @@ export default Ember.Controller.extend({
       this.get('store').createRecord('reminder', reminder).save().then(() => {
         this.setProperties({title: '', date: '', notes: ''});
       });
-    }
+    },
   }
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -11,6 +11,9 @@ export default Ember.Controller.extend({
     },
     saveChanges() {
       this.set('isEditing', false);
+    },
+    revertChanges() {
+      this.get('model').rollbackAttributes()
     }
   }
 });

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -4,7 +4,6 @@ export default Ember.Controller.extend({
   store: Ember.inject.service(),
 
   isEditable: false,
-  isDirty: false,
 
   actions: {
     editReminder() {

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -4,6 +4,7 @@ export default Ember.Controller.extend({
   store: Ember.inject.service(),
 
   isEditable: false,
+  isDirty: false,
 
   actions: {
     editReminder() {
@@ -13,7 +14,7 @@ export default Ember.Controller.extend({
       this.set('isEditing', false);
     },
     revertChanges() {
-      this.get('model').rollbackAttributes()
+      this.get('model').rollbackAttributes();
     }
   }
 });

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -22,6 +22,11 @@
           {{action 'saveChanges' on="click"}}>
           save
         </button>
+        <button
+        class="revert-button"
+        {{action 'revertChanges' on="click"}}>
+        revert
+      </button>
         {{else}}
           <p class="individual-note">{{model.notes}}</p>
           <button

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -24,7 +24,7 @@
         </button>
         <button
         class="revert-button"
-        {{action 'revertChanges' on="click"}}>
+        {{action 'revertChanges' on="click"}} hidden={{ unless model.hasDirtyAttributes 'true'}}>
         revert
       </button>
         {{else}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -57,3 +57,34 @@ test('clicking on Add Reminder and creating a new reminder which renders to the 
     assert.equal(Ember.$('.reminder-date:last').text().trim(), 'Sun Oct 30 2016 18:00:00 GMT-0600 (MDT)');
   });
 });
+
+  test('clicking on revert returns the reminder to the original state', function(assert) {
+    visit('/');
+    click('.add-reminder-button');
+    fillIn('.spec-input-title', 'hello');
+    fillIn('.spec-input-date', "2016-10-31");
+    fillIn('.spec-input-notes', 'Boo, Happy Halloween!');
+    click('.new-reminder-submit');
+    click('.spec-reminder-item:last');
+    click('.edit-button');
+
+
+    andThen(function() {
+      assert.equal(currentURL(), '/6');
+      assert.equal(find('.edit-title').val(), 'hello');
+    });
+
+    fillIn('.edit-title', 'hello123');
+
+    andThen(function() {
+      assert.equal(currentURL(), '/6');
+      assert.equal(find('.edit-title').val(), 'hello123');
+    });
+
+    click('.revert-button');
+
+    andThen(function() {
+      assert.equal(currentURL(), '/6');
+      assert.equal(find('.edit-title').val(), 'hello');
+    });
+});


### PR DESCRIPTION
@stevekinney @martensonbj @brittanystoroz 
## Purpose

_Describe the problem or feature in addition to a link to the issues. Delete any content that doesn't apply._
https://github.com/turingschool-projects/1606-remember-3/issues/11
Reminder should be able to be reverted to its original state by using the revert button. Revert should only be available once changes have been made.

## Approach

_How does this change address the problem?_

A revert button will appear once any edits are made to the reminder. Once revert is clicked the reminder will change back to its original state

### Learning

_Describe the research stage._

_Links to blog posts, patterns, libraries or add-ons used to solve this problem._

http://emberjs.com/api/data/classes/DS.Model.html#property_hasDirtyAttributes

http://emberjs.com/api/data/classes/DS.Model.html#method_rollbackAttributes

#### Blog Posts

### Open Questions and Pre-Merge TODOs

- [ ] Use Github checklists. When solved, check the box and explain the answer.

### Test coverage 

_Briefly describe what tests you have written and why._

### Merge Dependencies and Related Work

_Link to merge dependency issues or PRs._

### Follow-up tasks

- [Issue #12  (visual cues on unsaved reminders)](https://github.com/turingschool-projects/1606-remember-3/issues/12)

### Screenshots

#### Before
![](http://g.recordit.co/2xNALsx2bx.gif)

#### After
![](http://g.recordit.co/SHYLq6Lzxf.gif)

forget to close a few older issues that have already been merged in

closes #11 closes #4 closes #7 